### PR TITLE
feat: Add Django 6.0 support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
 
 # NOTE: Settings of this section below this line should not need to be changed
 
@@ -58,9 +59,9 @@ all_for_docs =
     %(flask)s
     %(quart)s
 django =
-    # Since we currently still supports Python 3.7, we choose Django version accordingly.
-    # See https://docs.djangoproject.com/en/5.0/faq/install/#what-python-version-can-i-use-with-django
-    django>=3.2,<6
+    # Django 6.0 requires Python 3.12+, Django 5.x requires Python 3.10+
+    # See https://docs.djangoproject.com/en/6.0/faq/install/#what-python-version-can-i-use-with-django
+    django>=3.2,<7
 flask =
     flask
     # If Flask-Session is not maintained in future, Flask-Session2 should work as well


### PR DESCRIPTION
## Summary

This PR adds support for Django 6.0 by updating the version constraint.

### Changes
- Updated Django version constraint from `>=3.2,<6` to `>=3.2,<7`
- Added Python 3.13 to classifiers
- Updated comment with Django 6.0 documentation link

### Rationale

Django 6.0 was released in December 2024. After reviewing the codebase, particularly `identity/django.py`, I found that this library only uses stable Django APIs:
- `django.shortcuts.redirect`
- `django.shortcuts.render`
- `django.urls.include`
- `django.urls.path`
- `django.urls.reverse`

None of these APIs have breaking changes in Django 6.0. The library should work without any code modifications.

### Testing

Tested with a Django 6.0 project and confirmed the library works correctly with the updated constraint.

### References
- [Django 6.0 Release Notes](https://docs.djangoproject.com/en/6.0/releases/6.0/)
- [Django Python Version Support](https://docs.djangoproject.com/en/6.0/faq/install/#what-python-version-can-i-use-with-django)